### PR TITLE
bump quassel version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG QUASSEL_VERSION="0.12.4"
+ARG QUASSEL_VERSION="0.12.5"
 
 RUN \
  echo "**** install build packages ****" && \


### PR DESCRIPTION
The quassel dev team just released a new version of Quassel which contains critical fixes for security vulnerabilities. The new version is 0.12.5 (https://quassel-irc.org/node/130).